### PR TITLE
Remove transaction variable used when initializing in connector

### DIFF
--- a/src/spaceone/cost_analysis/connector/sse_billing_connector.py
+++ b/src/spaceone/cost_analysis/connector/sse_billing_connector.py
@@ -27,8 +27,8 @@ _PAGE_SIZE = 1000
 
 class SSEBillingConnector(BaseConnector):
 
-    def __init__(self, transaction: Transaction, config: dict):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.endpoint = None
         self.headers = _DEFAULT_HEADERS
 


### PR DESCRIPTION
* As the transaction structure of the core framework changes, the transaction variable of the dependent microservice is removed.